### PR TITLE
[WIP] Switch to shunting-yard parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 language: rust
 
 rust:
-  - 1.0.0
+  - stable
+  - beta
   - nightly
 
 script:
   - cargo test
+
+matrix:
+  allow_failure:
+    - rust: nightly

--- a/benches/simple_benchmarks.rs
+++ b/benches/simple_benchmarks.rs
@@ -43,13 +43,37 @@ fn bench_deep_projection_104(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_expr_identifier(b: &mut Bencher) {
+fn bench_parse_identifier(b: &mut Bencher) {
     let expr = "abcdefghijklmnopqrstuvwxyz";
     b.iter(|| jmespath::parse(expr));
 }
 
 #[bench]
-fn bench_expr_subexpr(b: &mut Bencher) {
+fn bench_parse_subexpr(b: &mut Bencher) {
     let expr = "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_nested50(b: &mut Bencher) {
+    let expr = "j49.j48.j47.j46.j45.j44.j43.j42.j41.j40.j39.j38.j37.j36.j35.j34.j33.j32.j31.j30.j29.j28.j27.j26.j25.j24.j23.j22.j21.j20.j19.j18.j17.j16.j15.j14.j13.j12.j11.j10.j9.j8.j7.j6.j5.j4.j3.j2.j1.j0";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_nested50_pipe(b: &mut Bencher) {
+    let expr = "j49|j48|j47|j46|j45|j44|j43|j42|j41|j40|j39|j38|j37|j36|j35|j34|j33|j32|j31|j30|j29|j28|j27|j26|j25|j24|j23|j22|j21|j20|j19|j18|j17|j16|j15|j14|j13|j12|j11|j10|j9|j8|j7|j6|j5|j4|j3|j2|j1|j0";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_nested50_index(b: &mut Bencher) {
+    let expr = "[49][48][47][46][45][44][43][42][41][40][39][38][37][36][35][34][33][32][31][30][29][28][27][26][25][24][23][22][21][20][19][18][17][16][15][14][13][12][11][10][9][8][7][6][5][4][3][2][1][0]";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_raw_string_literal(b: &mut Bencher) {
+    let expr = "'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz'";
     b.iter(|| jmespath::parse(expr));
 }

--- a/benches/simple_benchmarks.rs
+++ b/benches/simple_benchmarks.rs
@@ -89,3 +89,21 @@ fn bench_parse_raw_string_literal(b: &mut Bencher) {
     let expr = "'abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz'";
     b.iter(|| jmespath::parse(expr));
 }
+
+#[bench]
+fn bench_parse_function_five_args(b: &mut Bencher) {
+    let expr = "function(foo, bar, baz, bam, qux)";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_mutli_list_five_exprs(b: &mut Bencher) {
+    let expr = "foo.[foo, bar, baz, bam, qux]";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_parse_filter_projection(b: &mut Bencher) {
+    let expr = "foo[bar > baz].qux";
+    b.iter(|| jmespath::parse(expr));
+}

--- a/benches/simple_benchmarks.rs
+++ b/benches/simple_benchmarks.rs
@@ -41,3 +41,15 @@ fn bench_deep_projection_104(b: &mut Bencher) {
     let deep = "a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*].a[*].b[*].c[*].d[*].e[*].f[*].g[*].h[*].i[*].j[*].k[*].l[*].m[*].n[*].o[*].p[*].q[*].r[*].s[*].t[*].u[*].v[*].w[*].x[*].y[*].z[*]";
     b.iter(|| jmespath::parse(deep));
 }
+
+#[bench]
+fn bench_expr_identifier(b: &mut Bencher) {
+    let expr = "abcdefghijklmnopqrstuvwxyz";
+    b.iter(|| jmespath::parse(expr));
+}
+
+#[bench]
+fn bench_expr_subexpr(b: &mut Bencher) {
+    let expr = "abcdefghijklmnopqrstuvwxyz.abcdefghijklmnopqrstuvwxyz";
+    b.iter(|| jmespath::parse(expr));
+}

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -5,7 +5,7 @@ extern crate rustc_serialize;
 use self::rustc_serialize::json::Json;
 use std::collections::BTreeMap;
 
-use ast::{Ast, Comparator, KeyValuePair};
+use ast::{Ast, Comparator};
 
 pub fn interpret(data: &Json, node: &Ast) -> Result<Json, String> {
     match node {
@@ -144,6 +144,7 @@ fn is_truthy(data: &Json) -> bool {
     }
 }
 
+/*
 fn jp_type(data: &Json) -> &str {
     match data {
         &Json::Boolean(_) => "boolean",
@@ -154,6 +155,7 @@ fn jp_type(data: &Json) -> &str {
         &Json::Null => "null"
     }
 }
+*/
 
 fn comparison(cmp: &Comparator, lhs: Json, rhs: Json) -> Json {
     match cmp {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -103,6 +103,23 @@ impl Token {
             _ => false
         }
     }
+
+    /// Returns true if the token is a nud token.
+    pub fn is_nud(&self) -> bool {
+        match self {
+            &Token::Identifier(_) => true,
+            &Token::Literal(_) => true,
+            &Token::QuotedIdentifier(_) => true,
+            &Token::At => true,
+            &Token::Star => true,
+            &Token::Flatten => true,
+            &Token::Filter => true,
+            &Token::Lbrace => true,
+            &Token::Ampersand => true,
+            &Token::Lbracket => true,
+            _ => false
+        }
+    }
 }
 
 /// The lexer is used to tokenize JMESPath expressions.

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -57,7 +57,6 @@ pub enum Token {
     Rparen,
     Lbrace,
     Rbrace,
-    Whitespace,
     Eof,
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -95,6 +95,14 @@ impl Token {
             _        => 0,
         }
     }
+
+    /// Returns true if the token is a number token.
+    pub fn is_number(&self) -> bool {
+        match *self {
+            Number(_) => true,
+            _ => false
+        }
+    }
 }
 
 /// The lexer is used to tokenize JMESPath expressions.
@@ -474,5 +482,17 @@ mod tests {
         assert_eq!("Unknown",
                    Unknown { value: "".to_string(), hint: "".to_string() }.token_name());
         assert_eq!("Dot".to_string(), Dot.token_name());
+    }
+
+    #[test] fn tokenizes_slices() {
+        let tokens: Vec<(usize, Token)> = tokenize("foo[0::-1]").collect();
+        assert_eq!("[(0, Identifier(\"foo\")), (3, Lbracket), (4, Number(0)), (5, Colon), \
+                     (6, Colon), (7, Number(-1)), (9, Rbracket), (10, Eof)]",
+                   format!("{:?}", tokens));
+    }
+
+    #[test] fn determines_if_number() {
+        assert_eq!(true, Token::Number(10).is_number());
+        assert_eq!(false, Token::Comma.is_number());
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -147,7 +147,8 @@ impl<'a> Lexer<'a> {
     // Consumes characters while the predicate function returns true.
     #[inline]
     fn consume_while<F>(&mut self, predicate: F) -> String
-        where F: Fn(char) -> bool {
+        where F: Fn(char) -> bool
+    {
         let mut buffer = self.iter.next().unwrap().1.to_string();
         loop {
             match self.iter.peek() {
@@ -211,7 +212,8 @@ impl<'a> Lexer<'a> {
     // can be escaped using a "\" character.
     #[inline]
     fn consume_inside<F>(&mut self, wrapper: char, invoke: F) -> Token
-        where F: Fn(String) -> Token {
+        where F: Fn(String) -> Token
+    {
         let mut buffer = String::new();
         // Skip the opening character.
         self.iter.next();

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -74,6 +74,7 @@ impl Token {
     }
 
     /// Provides the left binding power of the token.
+    #[inline]
     pub fn lbp(&self) -> usize {
         match *self {
             Pipe     => 1,
@@ -234,6 +235,7 @@ impl<'a> Lexer<'a> {
     }
 
     // Consume and parse a literal JSON token.
+    #[inline]
     fn consume_literal(&mut self) -> Token {
         self.consume_inside('`', |s| {
             match Json::from_str(s.as_ref()) {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -103,23 +103,6 @@ impl Token {
             _ => false
         }
     }
-
-    /// Returns true if the token is a nud token.
-    pub fn is_nud(&self) -> bool {
-        match self {
-            &Token::Identifier(_) => true,
-            &Token::Literal(_) => true,
-            &Token::QuotedIdentifier(_) => true,
-            &Token::At => true,
-            &Token::Star => true,
-            &Token::Flatten => true,
-            &Token::Filter => true,
-            &Token::Lbrace => true,
-            &Token::Ampersand => true,
-            &Token::Lbracket => true,
-            _ => false
-        }
-    }
 }
 
 /// The lexer is used to tokenize JMESPath expressions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //! ```
 //! use jmespath;
 //!
-//! let ast = jmespath::parse("foo.bar | baz");
+//! let ast = jmespath::parse("foo");
 //! ```
 
 extern crate rustc_serialize;
@@ -110,46 +110,4 @@ mod test {
     use self::rustc_serialize::json::Json;
     use super::*;
 
-    #[test] fn can_evaluate_jmespath_expression() {
-        let expr = Expression::new("foo.bar").unwrap();
-        let json = Json::from_str("{\"foo\":{\"bar\":true}}").unwrap();
-        assert_eq!(Json::Boolean(true), expr.search(json).unwrap());
-    }
-
-    #[test] fn formats_expression_as_string() {
-        let expr = Expression::new("foo | baz").unwrap();
-        assert_eq!("foo | baz/foo | baz", format!("{}/{:?}", expr, expr));
-    }
-
-    #[test] fn implements_partial_eq() {
-        let a = Expression::new("@").unwrap();
-        let b = Expression::new("@").unwrap();
-        assert!(a == b);
-    }
-
-    #[test] fn can_evaluate_wildcards() {
-        let expr = Expression::new("foo[*].bar").unwrap();
-        let json = Json::from_str("{\"foo\":[{\"bar\":true}]}").unwrap();
-        assert_eq!(Json::Array(vec![Json::Boolean(true)]), expr.search(json).unwrap());
-    }
-
-    #[test] fn can_evaluate_or_with_current_node() {
-        let expr = Expression::new("a || @").unwrap();
-        let json = Json::from_str("true").unwrap();
-        assert_eq!(Json::Boolean(true), expr.search(json).unwrap());
-    }
-
-    #[test] fn can_evaluate_flatten_projection() {
-        let expr = Expression::new("@[].b").unwrap();
-        let json = Json::from_str("[{\"b\": 1}, [{\"b\":2}]]").unwrap();
-        assert_eq!(Json::Array(vec!(Json::U64(1), Json::U64(2))),
-                   expr.search(json).unwrap());
-    }
-
-    #[test] fn can_evaluate_filter_projection() {
-        let expr = Expression::new("[?a > b]").unwrap();
-        let json = Json::from_str("[{\"a\": 2, \"b\": 1}, {\"a\": 0, \"b\":2}]").unwrap();
-        assert_eq!(Json::from_str("[{\"a\": 2, \"b\": 1}]").unwrap(),
-                   expr.search(json).unwrap());
-    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -188,7 +188,7 @@ impl<'a> Parser<'a> {
         // After parsing the expr, we should reach the end of the stream.
         match self.stream.next() {
             None | Some((_, Token::Eof)) => Ok(result),
-            token @ _ => Err(self.err(None, &"Did not reach token stream EOF"))
+            _ => Err(self.err(None, &"Did not reach token stream EOF"))
         }
     }
 
@@ -396,7 +396,7 @@ impl<'a> Parser<'a> {
         loop {
             match current_token {
                 Token::Rbracket => break,
-                ref t @ Token::Colon if pos == 2 =>
+                Token::Colon if pos == 2 =>
                     return Err(self.err(None, "Found too many colons in slice expression")),
                 Token::Colon => { pos += 1; current_token = self.advance(); },
                 Token::Number(value) => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -247,6 +247,7 @@ impl<'a> Parser<'a> {
                     }
                 }
             },
+            Token::Lbracket => self.open_lbracket(true),
             Token::At => {
                 self.output_stack.push(Ast::CurrentNode);
                 Ok(self.advance())
@@ -273,8 +274,7 @@ impl<'a> Parser<'a> {
                 let next_token = self.advance();
                 self.operator(next_token, Operator::Basic(Token::Ampersand))
             },
-            Token::Lbracket => self.open_lbracket(true),
-            ref tok @ _ => Err(self.err(Some(tok), &format!("Unexpected nud token: {}",
+            ref tok @ _ => Err(self.err(Some(tok), &format!("Unexpected prefix token: {}",
                                                             tok.token_name()))),
         }
     }
@@ -323,7 +323,7 @@ impl<'a> Parser<'a> {
                 }
             },
             _ => Err(self.err(Some(&token),
-                              &format!("Unexpected led token: {}", token.token_name()))),
+                              &format!("Unexpected postfix token: {}", token.token_name()))),
         }
     }
 
@@ -331,11 +331,7 @@ impl<'a> Parser<'a> {
     #[inline]
     fn start_filter(&mut self) -> ParseStep {
         let next_token = self.advance();
-        if !next_token.is_nud() {
-            Err(self.err(Some(&next_token), "Filters require a filter expression"))
-        } else {
-            self.operator(next_token, Operator::PartialFilter)
-        }
+        self.operator(next_token, Operator::PartialFilter)
     }
 
     #[inline]
@@ -883,8 +879,8 @@ mod test {
 
     #[test] fn test_ensures_filters_are_not_empty() {
         let result = parse("prefix[?].bar");
-        assert_eq!("Err(ParseError { msg: \"Parse error at line 0, col 8; Filters require a \
-                   filter expression\\nprefix[?].bar\\n        ^\\n\", line: 0, col: 8 })",
+        assert_eq!("Err(ParseError { msg: \"Parse error at line 0, col 8; Unexpected prefix \
+                   token: Rbracket\\nprefix[?].bar\\n        ^\\n\", line: 0, col: 8 })",
                    format!("{:?}", result));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -67,10 +67,7 @@ enum Operator {
     Basic(Token),
     Function(String),
     ArrayProjection,
-    SliceProjection(Option<i32>, Option<i32>, Option<i32>),
-    OpenParen,
-    OpenBracket,
-    OpenBrace,
+    SliceProjection(Option<i32>, Option<i32>, Option<i32>)
 }
 
 impl Operator {
@@ -106,10 +103,7 @@ impl Operator {
             &Operator::Basic(ref p) => p.lbp(),
             &Operator::Function(_) => Token::Lparen.lbp(),
             &Operator::ArrayProjection => Token::Star.lbp(),
-            &Operator::SliceProjection(_, _, _) => Token::Star.lbp(),
-            &Operator::OpenParen => Token::Lparen.lbp(),
-            &Operator::OpenBracket => Token::Lbracket.lbp(),
-            &Operator::OpenBrace => Token::Lbracket.lbp(),
+            &Operator::SliceProjection(_, _, _) => Token::Star.lbp()
         }
     }
 
@@ -122,11 +116,12 @@ impl Operator {
         }
     }
 
-    pub fn terminates(&self, token: &Token) -> bool {
+    // Returns true if the token closes the passed in token.
+    pub fn closes(&self, token: &Token) -> bool {
         match self {
-            &Operator::OpenParen if token == &Token::Rparen => true,
-            &Operator::OpenBracket if token == &Token::Rbracket => true,
-            &Operator::OpenBrace if token == &Token::Rbrace => true,
+            &Operator::Basic(ref p) if p == &Token::Lparen && token == &Token::Rparen => true,
+            &Operator::Basic(ref p) if p == &Token::Lbrace && token == &Token::Rbrace => true,
+            &Operator::Basic(ref p) if p == &Token::Lbracket && token == &Token::Rbracket => true,
             &Operator::Function(_) if token == &Token::Rparen => true,
             _ => false
         }
@@ -419,9 +414,6 @@ impl<'a> Parser<'a> {
                 Ast::Projection(Box::new(lhs), Box::new(rhs))),
             Operator::Function(fn_name) => panic!(),
             Operator::SliceProjection(start, step, stop) => panic!(),
-            Operator::OpenParen => panic!(),
-            Operator::OpenBrace => panic!(),
-            Operator::OpenBracket => panic!(),
         };
         Ok(())
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -559,7 +559,6 @@ impl<'a> Parser<'a> {
                                     Box::new(Ast::Condition(
                                         Box::new(expr),
                                         Box::new(rhs))))),
-                Operator::Function(fn_name, _) => panic!(),
                 Operator::SliceProjection(_, start, stop, step) => self.output_stack.push(
                     Ast::Subexpr(Box::new(lhs),
                                  Box::new(Ast::Projection(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,12 +4,14 @@ extern crate rustc_serialize;
 
 use std::iter::Peekable;
 use self::rustc_serialize::json::Json;
+use std::collections::VecDeque;
 
 use ast::{Ast, Comparator, KeyValuePair};
 use lexer::{Lexer, Token};
 
 /// An alias for computations that can return an `Ast` or `ParseError`.
 pub type ParseResult = Result<Ast, ParseError>;
+type ParseStep = Result<(), ParseError>;
 
 /// Parses a JMESPath expression into an AST
 pub fn parse(expr: &str) -> ParseResult {
@@ -61,6 +63,11 @@ impl ParseError {
     }
 }
 
+enum State {
+    Nud(usize),
+    Led(usize)
+}
+
 /// JMESPath parser. Returns an Ast
 pub struct Parser<'a> {
     /// Peekable token stream
@@ -71,6 +78,12 @@ pub struct Parser<'a> {
     token: Token,
     /// The current character offset in the expression
     pos: usize,
+    /// Operand queue containing AST nodes.
+    output_queue: VecDeque<Ast>,
+    /// Operator stack containing tokens.
+    operator_stack: Vec<Token>,
+    /// Stack of led RBP values to parse.
+    state_stack: Vec<State>
 }
 
 impl<'a> Parser<'a> {
@@ -83,6 +96,9 @@ impl<'a> Parser<'a> {
             expr: expr.to_string(),
             token: tok0,
             pos: 0,
+            operator_stack: vec!(),
+            output_queue: VecDeque::new(),
+            state_stack: vec!()
         }
     }
 
@@ -100,141 +116,145 @@ impl<'a> Parser<'a> {
             })
     }
 
-    /// Main parse function of the Pratt parser that parses while RBP < LBP
     fn expr(&mut self, rbp: usize) -> ParseResult {
-        let mut left = self.nud();
-        while rbp < self.token.lbp() {
-            left = self.led(try!(left), &rbp);
+        self.state_stack.push(State::Nud(0));
+        while self.token != Token::Eof {
+            match self.state_stack.last() {
+                Some(&State::Nud(rbp)) => {
+                    self.state_stack.pop();
+                    self.nud();
+                    self.state_stack.push(State::Led(rbp));
+                },
+                Some(&State::Led(rbp)) => {
+                    if (rbp < self.token.lbp()) {
+                        self.led();
+                    } else {
+                        self.state_stack.pop();
+                    }
+                },
+                None => break
+            }
         }
-        left
+        while !self.operator_stack.is_empty() {
+            try!(self.pop_token());
+        }
+        match self.output_queue.pop_back() {
+            Some(ast) => Ok(ast),
+            None => Err(self.err(&"Unexpected end of token stream"))
+        }
     }
 
-    fn nud(&mut self) -> ParseResult {
+    fn nud(&mut self) -> ParseStep {
         match self.token.clone() {
             Token::At => {
                 self.advance();
-                Ok(Ast::CurrentNode)
+                self.output_queue.push_front(Ast::CurrentNode);
+                Ok(())
             },
             Token::Identifier { value, .. } => {
                 self.advance();
-                Ok(Ast::Identifier(value))
+                self.output_queue.push_front(Ast::Identifier(value));
+                Ok(())
             },
             Token::QuotedIdentifier { value, .. } => {
                 self.advance();
                 match self.token {
-                    Token::Lparen => Err(self.err(&"Quoted strings can't be a function name")),
-                    _ => Ok(Ast::Identifier(value))
-                }
-            },
-            Token::Star => {
-                self.advance();
-                self.parse_wildcard_values(Ast::CurrentNode)
-            },
-            Token::Lbracket => {
-                self.advance();
-                match self.token {
-                    Token::Number { .. } | Token::Colon => self.parse_array_index(),
-                    Token::Star => {
-                        if self.stream.peek() != Some(&Token::Rbracket) {
-                            self.parse_multi_list()
-                        } else {
-                            try!(self.expect("Star"));
-                            self.parse_wildcard_index(Ast::CurrentNode)
-                        }
-                    },
-                    _ => self.parse_multi_list()
-                }
-            },
-            Token::Flatten => self.parse_flatten(Ast::CurrentNode),
-            Token::Literal { value, .. } => {
-                self.advance();
-                Ok(Ast::Literal(value))
-            },
-            Token::Lbrace => {
-                let mut pairs = vec![];
-                loop {
-                    // Skip the opening brace and any encountered commas.
-                    self.advance();
-                    // Requires at least on key value pair.
-                    pairs.push(try!(self.parse_kvp()));
-                    match self.token {
-                        // Terminal condition is the Rbrace token "}".
-                        Token::Rbrace => { self.advance(); break; },
-                        // Skip commas as they are used to delineate kvps
-                        Token::Comma => continue,
-                        _ => return Err(self.err("Expected '}' or ','"))
+                    Token::Lparen => Err(self.err(&"Quoted strings can't be function names")),
+                    _ => {
+                        self.output_queue.push_front(Ast::Identifier(value));
+                        Ok(())
                     }
                 }
-                Ok(Ast::MultiHash(pairs))
             },
-            Token::Ampersand => {
+            Token::Literal { value, .. } => {
                 self.advance();
-                let rhs = try!(self.expr(Token::Ampersand.lbp()));
-                Ok(Ast::Expref(Box::new(rhs)))
+                self.output_queue.push_front(Ast::Literal(value));
+                Ok(())
             },
-            Token::Filter => self.parse_filter(Ast::CurrentNode),
-            ref tok @ _ => return Err(self.err(&format!("Unexpected nud token: {}",
-                                                        tok.token_name()))),
+            ref tok @ _ => Err(self.err(&format!("Unexpected nud token: {}",
+                                                 tok.token_name()))),
         }
     }
 
-    fn led(&mut self, left: Ast, rbp: &usize) -> ParseResult {
+    fn led(&mut self) -> ParseStep  {
         match self.token {
             Token::Dot => {
                 if self.stream.peek() == Some(&Token::Star) {
                     self.advance();
                     self.advance();
-                    self.parse_wildcard_values(left)
+                    try!(self.operator(Token::Star));
                 } else {
-                    let rhs = try!(self.parse_dot(Token::Dot.lbp()));
-                    Ok(Ast::Subexpr(Box::new(left), Box::new(rhs)))
+                    self.advance();
+                    self.state_stack.push(State::Nud(Token::Dot.lbp()));
+                    try!(self.operator(Token::Dot));
                 }
+                Ok(())
             },
-            Token::Lbracket => {
-                try!(self.expect("Number|Colon|Star"));
-                match self.token {
-                    Token::Number {.. } | Token::Colon => {
-                        Ok(Ast::Subexpr(Box::new(left),
-                                        Box::new(try!(self.parse_array_index()))))
-                    },
-                    _ => self.parse_wildcard_index(left)
-                }
-            },
-            Token::Flatten => self.parse_flatten(left),
             Token::Or => {
                 self.advance();
-                let rhs = try!(self.expr(Token::Or.lbp()));
-                Ok(Ast::Or(Box::new(left), Box::new(rhs)))
+                self.state_stack.push(State::Nud(Token::Or.lbp()));
+                try!(self.operator(Token::Or));
+                Ok(())
             },
             Token::Pipe => {
                 self.advance();
-                let rhs = try!(self.expr(Token::Pipe.lbp()));
-                Ok(Ast::Subexpr(Box::new(left), Box::new(rhs)))
+                self.state_stack.push(State::Nud(Token::Pipe.lbp()));
+                try!(self.operator(Token::Pipe));
+                Ok(())
             },
-            Token::Lparen => {
-                match left {
-                    Ast::Identifier(v) => {
-                        self.advance();
-                        Ok(Ast::Function(v, try!(self.parse_list(Token::Rparen))))
-                    },
-                    _ => Err(self.err("Functions must be preceded by an identifier"))
-                }
-            },
-            Token::Filter => self.parse_filter(left),
-            Token::Eq => self.parse_comparator(Comparator::Eq, left),
-            Token::Ne => self.parse_comparator(Comparator::Ne, left),
-            Token::Gt => self.parse_comparator(Comparator::Gt, left),
-            Token::Gte => self.parse_comparator(Comparator::Gte, left),
-            Token::Lt => self.parse_comparator(Comparator::Lt, left),
-            Token::Lte => self.parse_comparator(Comparator::Lte, left),
             _ => Err(self.err(&format!("Unexpected led token: {}",
-                                       self.token.token_name()))),
+                              self.token.token_name()))),
+        }
+    }
+
+    fn operator(&mut self, token: Token) -> ParseStep {
+        loop {
+            // Pop things from the top of the operator stack that have a higher precedence.
+            match self.last_operator_lbp() {
+                // Use <= for left-associative, and < for right associative.
+                Some(rbp) if token.lbp() <= rbp => self.pop_token(),
+                _ => {
+                    self.operator_stack.push(token);
+                    return Ok(());
+                }
+            };
+        }
+    }
+
+    fn last_operator_lbp(&self) -> Option<usize> {
+        match self.operator_stack.last() {
+            Some(ref top) => Some(top.lbp()),
+            None => None
+        }
+    }
+
+    fn pop_token(&mut self) -> ParseStep {
+        match self.operator_stack.pop().unwrap() {
+            Token::Dot => {
+                let rhs = self.output_queue.pop_front().unwrap();
+                let lhs = self.output_queue.pop_front().unwrap();
+                self.output_queue.push_front(Ast::Subexpr(Box::new(lhs), Box::new(rhs)));
+                Ok(())
+            },
+            Token::Or => {
+                let rhs = self.output_queue.pop_front().unwrap();
+                let lhs = self.output_queue.pop_front().unwrap();
+                self.output_queue.push_front(Ast::Or(Box::new(lhs), Box::new(rhs)));
+                Ok(())
+            },
+            Token::Pipe => {
+                let rhs = self.output_queue.pop_front().unwrap();
+                let lhs = self.output_queue.pop_front().unwrap();
+                self.output_queue.push_front(Ast::Subexpr(Box::new(lhs), Box::new(rhs)));
+                Ok(())
+            },
+            _ => Err(self.err(&"Unexpected led token"))
         }
     }
 
     /// Ensures that a Token is one of the pipe separated token names
     /// provided as the edible argument (e.g., "Identifier|Eof").
-    fn validate(&self, token: &Token, edible: &str) -> Result<(), ParseError> {
+    fn validate(&self, token: &Token, edible: &str) -> ParseStep {
         let token_name = token.token_name();
         if edible.contains(&token_name) {
             Ok(())
@@ -246,7 +266,7 @@ impl<'a> Parser<'a> {
     /// Ensures that the next token in the token stream is one of the pipe
     /// separated token names provided as the edible argument (e.g.,
     /// "Identifier|Eof").
-    fn expect(&mut self, edible: &str) -> Result<(), ParseError> {
+    fn expect(&mut self, edible: &str) -> ParseStep {
         self.advance();
         self.validate(&self.token, edible)
     }
@@ -275,361 +295,51 @@ impl<'a> Parser<'a> {
     fn token_err(&self) -> ParseError {
         self.err(&format!("Unexpected token: {}", self.token.token_name()))
     }
-
-    fn parse_kvp(&mut self) -> Result<KeyValuePair, ParseError> {
-        match self.token.clone() {
-            Token::Identifier { value, .. } => {
-                try!(self.expect("Colon"));
-                self.advance();
-                Ok(KeyValuePair {
-                    key: Ast::Literal(Json::String(value)),
-                    value: try!(self.expr(0))
-                })
-            },
-            _ => Err(self.err("Expected Identifier to start key value pair"))
-        }
-    }
-
-    /// Parses a filter token into a Projection that filters the right
-    /// side of the projection using a Condition node. If the Condition node
-    /// returns a truthy value, then the value is yielded by the projection.
-    fn parse_filter(&mut self, lhs: Ast) -> ParseResult {
-        self.advance();
-        // Parse the LHS of the condition node.
-        let condition_lhs = try!(self.expr(0));
-        // Eat the closing bracket.
-        try!(self.validate(&self.token, "Rbracket"));
-        self.advance();
-        let condition_rhs = Box::new(try!(self.projection_rhs(Token::Filter.lbp())));
-        Ok(Ast::Projection(
-            Box::new(lhs),
-            Box::new(
-                Ast::Condition(
-                    Box::new(condition_lhs),
-                    condition_rhs))))
-    }
-
-    fn parse_flatten(&mut self, lhs: Ast) -> ParseResult {
-        self.advance();
-        let rhs = try!(self.projection_rhs(Token::Flatten.lbp()));
-        Ok(Ast::Projection(
-            Box::new(Ast::Flatten(Box::new(lhs))),
-            Box::new(rhs)
-        ))
-    }
-
-    /// Parses a comparator token into a Comparison (e.g., foo == bar)
-    fn parse_comparator(&mut self, cmp: Comparator, lhs: Ast) -> ParseResult {
-        let lbp = self.token.lbp();
-        self.advance();
-        let rhs = try!(self.expr(lbp));
-        Ok(Ast::Comparison(cmp, Box::new(lhs), Box::new(rhs)))
-    }
-
-    /// Parses the right hand side of a dot expression.
-    fn parse_dot(&mut self, lbp: usize) -> ParseResult {
-        try!(self.expect("Identifier|Star|Lbrace|Lbracket|Ampersand|Filter"));
-        match self.token {
-            Token::Lbracket => { self.advance(); self.parse_multi_list() },
-            _ => self.expr(lbp)
-        }
-    }
-
-    /// Parses the right hand side of a projection, using the given LBP to
-    /// determine when to stop consuming tokens.
-    fn projection_rhs(&mut self, lbp: usize) -> ParseResult {
-        if self.token.lbp() < 10 {
-            return Ok(Ast::CurrentNode);
-        }
-        match self.token {
-            Token::Dot      => self.parse_dot(lbp),
-            Token::Lbracket => self.expr(lbp),
-            Token::Filter   => self.expr(lbp),
-            _               => Err(self.token_err())
-        }
-    }
-
-    /// Creates a projection for "[*]"
-    fn parse_wildcard_index(&mut self, lhs: Ast) -> ParseResult {
-        try!(self.expect("Rbracket"));
-        self.advance();
-        let rhs = try!(self.projection_rhs(Token::Star.lbp()));
-        Ok(Ast::Projection(Box::new(lhs), Box::new(rhs)))
-    }
-
-    /// Creates a projection for "*"
-    fn parse_wildcard_values(&mut self, lhs: Ast) -> ParseResult {
-        let rhs = try!(self.projection_rhs(Token::Star.lbp()));
-        Ok(Ast::Projection(
-            Box::new(Ast::ObjectValues(Box::new(lhs))),
-            Box::new(rhs)))
-    }
-
-    /// Parses [0], [::-1], [0:-1], [0:1], etc...
-    fn parse_array_index(&mut self) -> ParseResult {
-        let mut parts = [None, None, None];
-        let mut pos = 0;
-        loop {
-            match self.token {
-                Token::Colon if pos >= 2 => {
-                    return Err(self.err("Too many colons in slice expr"));
-                },
-                Token::Colon => {
-                    pos += 1;
-                    try!(self.expect("Number|Colon|Rbracket"));
-                },
-                Token::Number { value, .. } => {
-                    parts[pos] = Some(value);
-                    try!(self.expect("Colon|Rbracket"));
-                },
-                Token::Rbracket => { self.advance(); break; },
-                _ => return Err(self.token_err()),
-            }
-        }
-
-        if pos == 0 {
-            // No colons were found, so this is a simple index extraction.
-            Ok(Ast::Index(parts[0].unwrap()))
-        } else {
-            // Sliced array from start (e.g., [2:])
-            let lhs = Ast::Slice(parts[0], parts[1], parts[2]);
-            let rhs = try!(self.projection_rhs(Token::Star.lbp()));
-            Ok(Ast::Projection(Box::new(lhs), Box::new(rhs)))
-        }
-    }
-
-    /// Parses multi-select lists (e.g., "[foo, bar, baz]")
-    fn parse_multi_list(&mut self) -> ParseResult {
-        Ok(Ast::MultiList(try!(self.parse_list(Token::Rbracket))))
-    }
-
-    /// Parse a comma separated list of expressions until a closing token.
-    ///
-    /// This function is used for functions and multi-list parsing. Note
-    /// that this function allows empty lists. This is fine when parsing
-    /// multi-list expressions because "[]" is tokenized as Token::Flatten.
-    ///
-    /// Examples: [foo, bar], foo(bar), foo(), foo(baz, bar)
-    fn parse_list(&mut self, closing: Token) -> Result<Vec<Ast>, ParseError> {
-        let mut nodes = vec![];
-        while self.token != closing {
-            nodes.push(try!(self.expr(0)));
-            if self.token == Token::Comma {
-                self.advance();
-            }
-        }
-        self.advance();
-        Ok(nodes)
-    }
 }
 
 #[cfg(test)]
 mod test {
     extern crate rustc_serialize;
+    use self::rustc_serialize::json::Json;
     use super::*;
     use ast::{Ast, Comparator, KeyValuePair};
-    use self::rustc_serialize::json::Json;
 
-    #[test] fn indentifier_test() {
-        assert_eq!(parse("foo").unwrap(),
-                   Ast::Identifier("foo".to_string()));
+    #[test] fn test_parse_nud() {
+        let ast = parse("foo").unwrap();
+        assert_eq!(ast, Ast::Identifier("foo".to_string()));
     }
 
-    #[test] fn current_node_test() {
-        assert_eq!(parse("@").unwrap(), Ast::CurrentNode);
+    #[test] fn test_parse_subexpr() {
+        let ast = parse("foo.bar.baz").unwrap();
+        assert_eq!(ast, Ast::Subexpr(
+            Box::new(Ast::Subexpr(Box::new(Ast::Identifier("foo".to_string())),
+                         Box::new(Ast::Identifier("bar".to_string())))),
+            Box::new(Ast::Identifier("baz".to_string()))));
     }
 
-    #[test] fn wildcard_values_test() {
-        assert_eq!(parse("*").unwrap(),
-                   Ast::Projection(
-                       Box::new(Ast::ObjectValues(Box::new(Ast::CurrentNode))),
-                       Box::new(Ast::CurrentNode)));
+    #[test] fn test_parse_or() {
+        let ast = parse("foo || bar").unwrap();
+        assert_eq!(ast, Ast::Or(Box::new(Ast::Identifier("foo".to_string())),
+                                Box::new(Ast::Identifier("bar".to_string()))));
     }
 
-    #[test] fn dot_test() {
-        assert_eq!(parse("@.b").unwrap(),
-                  Ast::Subexpr(Box::new(Ast::CurrentNode),
-                               bident(&"b")));
+    #[test] fn test_parse_or_and_subexpr_with_precedence() {
+        let ast = parse("foo.baz || bar.bam").unwrap();
+        let expected = Ast::Or(
+            Box::new(Ast::Subexpr(Box::new(Ast::Identifier("foo".to_string())),
+                                  Box::new(Ast::Identifier("baz".to_string())))),
+            Box::new(Ast::Subexpr(Box::new(Ast::Identifier("bar".to_string())),
+                                  Box::new(Ast::Identifier("bam".to_string())))));
+        assert_eq!(ast, expected);
     }
 
-    #[test] fn ensures_nud_token_is_valid_test() {
-        let result = parse(",");
-        assert!(result.is_err());
-        assert!(result.err().unwrap().msg.contains("Unexpected nud token: Comma"));
-    }
-
-    #[test] fn multi_list_test() {
-        let l = Ast::MultiList(vec![ident(&"a"), ident(&"b")]);
-        assert_eq!(parse("[a, b]").unwrap(), l);
-    }
-
-    #[test] fn multi_list_unclosed() {
-        let result = parse("[a, b");
-        assert!(result.is_err());
-        assert!(result.err().unwrap().msg.contains("Unexpected nud token"));
-    }
-
-    #[test] fn multi_list_unclosed_after_comma() {
-        let result = parse("[a,");
-        assert!(result.is_err());
-        assert!(result.err().unwrap().msg.contains("Unexpected nud token"));
-    }
-
-    #[test] fn parse_error_includes_lexer_hints_test() {
-        let result = parse(" \"foo");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().msg,
-                   "Parse error at line 0, col 1; Unexpected nud token: Unknown\n \"foo\n ^\n\
-                   Hint: Unclosed \" delimiter".to_string())
-    }
-
-    #[test] fn parse_error_on_column_zero_test() {
-        let result = parse("]");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().msg,
-                   "Parse error at line 0, col 0; Unexpected nud token: Rbracket\n\
-                   ]\n^\n".to_string());
-    }
-
-    #[test] fn parse_error_injected_before_eof_test() {
-        let result = parse("`\"foo\"` ||\n\n ]\n....]\n.");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().msg,
-                   "Parse error at line 2, col 1; Unexpected nud token: Rbracket\n\
-                   `\"foo\"` ||\n\n ]\n ^\n".to_string());
-    }
-
-    #[test] fn can_parse_with_leading_whitespace_tokens_test() {
-        assert_eq!(parse("\n\n`\"foo\"`").unwrap(),
-                   Ast::Literal(Json::String("foo".to_string())))
-    }
-
-    #[test] fn multi_list_after_dot_test() {
-        let l = Ast::MultiList(vec![ident(&"a"), ident(&"b")]);
-        assert_eq!(parse("@.[a, b]").unwrap(),
-                   Ast::Subexpr(Box::new(Ast::CurrentNode),
-                                Box::new(l)));
-    }
-
-    #[test] fn parses_simple_index_extractions_test() {
-        assert_eq!(parse("[0]").unwrap(), Ast::Index(0));
-    }
-
-    #[test] fn parses_single_element_slice_test() {
-        assert_eq!(parse("[-1:]").unwrap(),
-                   Ast::Projection(Box::new(Ast::Slice(Some(-1), None, None)),
-                                   Box::new(Ast::CurrentNode)));
-    }
-
-    #[test] fn parses_double_element_slice_test() {
-        assert_eq!(parse("[1:-1].a").unwrap(),
-                   Ast::Projection(Box::new(Ast::Slice(Some(1), Some(-1), None)),
-                                   bident(&"a")));
-    }
-
-    #[test] fn parses_revese_slice_test() {
-        assert_eq!(parse("[::-1].a").unwrap(),
-                   Ast::Projection(Box::new(Ast::Slice(None, None, Some(-1))),
-                                   bident(&"a")));
-    }
-
-    #[test] fn parses_or_test() {
-        let result = Ast::Or(bident(&"a"), bident(&"b"));
-        assert_eq!(parse("a || b").unwrap(), result);
-    }
-
-    #[test] fn parses_pipe_test() {
-        let result = Ast::Subexpr(bident(&"a"), bident(&"b"));
-        assert_eq!(parse("a | b").unwrap(), result);
-    }
-
-    #[test] fn parses_literal_token_test() {
-        assert_eq!(parse("`\"foo\"`").unwrap(),
-                   Ast::Literal(Json::String("foo".to_string())))
-    }
-
-    #[test] fn parses_multi_hash() {
-        let result = Ast::MultiHash(vec![
-            KeyValuePair {
-                key: Ast::Literal(Json::String("foo".to_string())),
-                value: ident(&"bar")
-            },
-            KeyValuePair {
-                key: Ast::Literal(Json::String("baz".to_string())),
-                value: ident(&"bam")
-            }
-        ]);
-        assert_eq!(parse("{foo: bar, baz: bam}").unwrap(), result);
-    }
-
-    #[test] fn parses_functions() {
-        let r = Ast::Function("length".to_string(), vec![ident(&"a")]);
-        assert_eq!(parse("length(a)").unwrap(), r);
-    }
-
-    #[test] fn parses_functions_with_no_args() {
-        let r = Ast::Function("length".to_string(), vec![]);
-        assert_eq!(parse("length()").unwrap(), r);
-    }
-
-    #[test] fn ensures_functions_cannot_start_with_quoted_identifier() {
-        let result = parse("\"foo\"(baz, bar)");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().msg,
-                   "Parse error at line 0, col 5; Quoted strings can't \
-                   be a function name\n\
-                   \"foo\"(baz, bar)\n     ^\n".to_string());
-    }
-
-    #[test] fn parses_expref() {
-        let result = Ast::Expref(bident(&"foo"));
-        assert_eq!(parse("&foo").unwrap(), result);
-    }
-
-    #[test] fn parses_comparisons() {
-        let result = Ast::Comparison(Comparator::Eq, bident(&"foo"), bident(&"bar"));
-        assert_eq!(parse("foo == bar").unwrap(), result);
-    }
-
-    #[test] fn parses_filters() {
-        let comp = Ast::Comparison(Comparator::Eq, bident(&"foo"), bident(&"bar"));
-        let proj = Ast::Projection(
-            Box::new(Ast::CurrentNode),
-            Box::new(Ast::Condition(
-                Box::new(comp),
-                bident(&"bar")
-            ))
+    #[test] fn test_parse_or_and_pipe_with_precedence() {
+        let ast = parse("foo || bar | baz").unwrap();
+        let expected = Ast::Subexpr(
+            Box::new(Ast::Or(Box::new(Ast::Identifier("foo".to_string())),
+                             Box::new(Ast::Identifier("bar".to_string())))),
+            Box::new(Ast::Identifier("baz".to_string()))
         );
-        assert_eq!(parse("[?foo == bar].bar").unwrap(), proj);
-    }
-
-    #[test] fn ensures_filter_has_closing_rbracket() {
-        let result = parse("[?foo == bar | baz");
-        assert!(result.is_err());
-        assert_eq!(result.err().unwrap().msg,
-                   "Parse error at line 0, col 17; Expected Rbracket, found Eof\n\
-                   [?foo == bar | baz\n                 ^\n".to_string());
-    }
-
-    #[test] fn parses_wildcard_array() {
-        let ast = Ast::Projection(
-            Box::new(Ast::Identifier("foo".to_string())),
-            Box::new(Ast::Identifier("bar".to_string())));
-        assert_eq!(ast, parse("foo[*].bar").unwrap());
-    }
-
-    #[test] fn parses_wildcard_object() {
-        let ast = Ast::Projection(
-            Box::new(Ast::ObjectValues(Box::new(Ast::Identifier("foo".to_string())))),
-            Box::new(Ast::Identifier("bar".to_string())));
-        assert_eq!(ast, parse("foo.*.bar").unwrap());
-    }
-
-    fn bident(name: &str) -> Box<Ast> {
-        Box::new(ident(name))
-    }
-
-    fn ident(name: &str) -> Ast {
-        Ast::Identifier(name.to_string())
+        assert_eq!(ast, expected);
     }
 }


### PR DESCRIPTION
This pull request is a WIP to update the parser to not use recursion. Instead of using a Pratt parser like other JMESPath implementations, we are using a shunting-yard based parser. This allows the parser to better handle extremely long expressions (e.g., `a[*].b[*].c[*]...repeated`) without exhausting the stack space due to weird inlining problems. It's also much faster than the Pratt parser approach in most cases.

- [x] Implement multi-hash parsing.
- [x] Implement filter projection parsing.
- [x] Cleanup parser implementation.
- [x] Remove the `state_stack` if possible.