### PR TITLE
Allow usage with stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ sudo: false
 
 # run builds for all the trains (and more)
 rust:
-  #- stable
-  #- beta
+  - stable
+  - beta
   - nightly
 
 matrix:
@@ -24,7 +24,7 @@ script:
   - |
       travis-cargo build &&
       travis-cargo test &&
-      travis-cargo test --features specialized &&
+      travis-cargo --only nightly test -- --features specialized &&
       travis-cargo bench
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - |
       travis-cargo build &&
       travis-cargo test &&
+      travis-cargo test --features specialized &&
       travis-cargo bench
 
 after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ slug = "0.1.2"
 
 [features]
 sync = []
+# `specialized` enables the use of specialization for more efficient code
+# however at time of writing it is unstable & so requires a nightly compiler.
+# See https://github.com/rust-lang/rust/issues/31844 for the latest status.
+specialized = []

--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ by adding `jmespath` to the dependencies in your project's `Cargo.toml`.
 jmespath = "0.1"
 ```
 
+If you are using a nightly compiler, or reading this when specialization in Rust
+is stable (see [rust#31844](https://github.com/rust-lang/rust/issues/31844)), then
+enable the `specialized` feature to switch on usage of specialization to get more
+efficient code:
+
+[dependencies.jmespath]
+version = "0.1"
+features = ["specialized"]
+
 ## Examples
 
 ```rust

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -304,7 +304,10 @@ impl<'a> Lexer<'a> {
 
 #[cfg(test)]
 mod tests {
+    use ::Rcvar;
+    use ::variable::Variable;
     use super::*;
+    use super::Token::*;
 
     fn tokenize_queue(expr: &str) -> Vec<TokenTuple> {
         let mut result = tokenize(expr).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! assert_eq!("bar", expr.search(()).unwrap().as_string().unwrap());
 //! ```
 
-#![feature(specialization)]
+#![cfg_attr(feature = "specialized", feature(specialization))]
 
 #[macro_use]
 extern crate lazy_static;
@@ -113,6 +113,7 @@ pub mod functions;
 
 use std::fmt;
 use serde::ser;
+#[cfg(feature = "specialized")]
 use serde_json::Value;
 
 use ast::Ast;
@@ -155,15 +156,34 @@ pub fn compile(expression: &str) -> Result<Expression<'static>, JmespathError> {
 
 /// Converts a value into a reference-counted JMESPath Variable.
 ///
-/// There are a number of implemenations for ToJmespath built into the
-/// library that should work for most cases, including a generic serde
-/// Serialize implemenation.
+#[cfg_attr(feature = "specialized", doc = "\
+There is a generic serde Serialize implementation, and since this
+documentation was compiled with the `specialized` feature turned
+**on**, there are also a number of specialized implementations for
+`ToJmespath` built into the library that should work for most
+cases.")]
+#[cfg_attr(not(feature = "specialized"), doc = "\
+There is a generic serde Serialize implementation. Since this
+documentation was compiled with the `specialized` feature turned
+**off**, this is the only implementation available.
+
+(If the `specialized` feature were turned on, there there would be
+a number of additional specialized implementations for `ToJmespath`
+built into the library that should work for most cases.)")]
 pub trait ToJmespath {
     fn to_jmespath(self) -> Rcvar;
 }
 
 /// Create searchable values from Serde serializable values.
 impl<'a, T: ser::Serialize> ToJmespath for T {
+    #[cfg(not(feature = "specialized"))]
+    fn to_jmespath(self) -> Rcvar {
+        let mut ser = Serializer::new();
+        self.serialize(&mut ser).ok().unwrap();
+        Rcvar::new(ser.unwrap())
+    }
+
+    #[cfg(feature = "specialized")]
     default fn to_jmespath(self) -> Rcvar {
         let mut ser = Serializer::new();
         self.serialize(&mut ser).ok().unwrap();
@@ -171,6 +191,7 @@ impl<'a, T: ser::Serialize> ToJmespath for T {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for Value {
     #[inline]
     fn to_jmespath(self) -> Rcvar {
@@ -178,6 +199,7 @@ impl ToJmespath for Value {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl<'a> ToJmespath for &'a Value {
     #[inline]
     fn to_jmespath(self) -> Rcvar {
@@ -185,6 +207,7 @@ impl<'a> ToJmespath for &'a Value {
     }
 }
 
+#[cfg(feature = "specialized")]
 /// Identity coercion.
 impl ToJmespath for Rcvar {
     #[inline]
@@ -193,6 +216,7 @@ impl ToJmespath for Rcvar {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl<'a> ToJmespath for &'a Rcvar {
     #[inline]
     fn to_jmespath(self) -> Rcvar {
@@ -200,6 +224,7 @@ impl<'a> ToJmespath for &'a Rcvar {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for Variable {
     #[inline]
     fn to_jmespath(self) -> Rcvar {
@@ -207,6 +232,7 @@ impl ToJmespath for Variable {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl<'a> ToJmespath for &'a Variable {
     #[inline]
     fn to_jmespath(self) -> Rcvar {
@@ -214,96 +240,112 @@ impl<'a> ToJmespath for &'a Variable {
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for String {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::String(self))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl<'a> ToJmespath for &'a str {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::String(self.to_owned()))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for i8 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for i16 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for i32 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for i64 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for u8 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for u16 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for u32 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for u64 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for isize {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for usize {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for f32 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for f64 {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Number(self as f64))
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for () {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Null)
     }
 }
 
+#[cfg(feature = "specialized")]
 impl ToJmespath for bool {
     fn to_jmespath(self) -> Rcvar {
         Rcvar::new(Variable::Bool(self))

--- a/src/variable.rs
+++ b/src/variable.rs
@@ -1332,7 +1332,7 @@ impl ser::Serializer for Serializer {
 
 #[cfg(test)]
 mod tests {
-    use super::Rcvar;
+    use ::Rcvar;
     use std::collections::BTreeMap;
     use super::serde_json::{self, Value};
     use super::{Variable, JmespathType};


### PR DESCRIPTION
The meat of this change is putting the usage of specialization behind a `specialized` feature flag, such that on stable Rust this library always uses `impl<'a, T: ser::Serialize> ToJmespath for T`.

After I did that, I needed to tweak some of the imports, as (for reasons I don't quite understand) nightly Rust treats imports slightly differently than stable Rust does.

Benchmarks (on `rustc 1.16.0-nightly (6f1ae663e 2017-01-06)`) [show the version without specialization is between 2-10x slower](https://docs.google.com/spreadsheets/d/1lyDoSweo1Z7zFyFbJjwI_prhZCdBUc8inecq5iM_Txg).

But I'd rather have code running 2-10x slower than not be able to use the functionality at all in my project :)