### PR TITLE
Fix syntactic error on nightly Rust

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -93,13 +93,13 @@ pub struct CustomFunction {
     /// Signature used to validate the function.
     signature: Signature,
     /// Function to invoke after validating the signature.
-    f: Box<(Fn(&[Rcvar], &mut Context) -> SearchResult) + Sync>,
+    f: Box<Fn(&[Rcvar], &mut Context) -> SearchResult + Sync>,
 }
 
 impl CustomFunction {
     /// Creates a new custom function.
     pub fn new(fn_signature: Signature,
-               f: Box<(Fn(&[Rcvar], &mut Context) -> SearchResult) + Sync>)
+               f: Box<Fn(&[Rcvar], &mut Context) -> SearchResult + Sync>)
                -> CustomFunction {
         CustomFunction {
             signature: fn_signature,


### PR DESCRIPTION
The parentheses around `Fn` are actually a syntactic error, but they were accepted by mistake since Rust 1.6 (https://github.com/rust-lang/rust/issues/39318). This will be fixed soon (https://github.com/rust-lang/rust/pull/40043) and this code is going to stop compiling.