### PR TITLE
Upgrade to serde 1.0 by implementing serialization directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ license = "MIT"
 build = "build.rs"
 
 [dependencies]
-serde = "^0.8"
-serde_json = "^0.8"
+serde = { version = "1", features = ["rc"] }
+serde_json = "1"
 lazy_static = "^0.2.2"
 
 [build-dependencies]
-serde_json = "^0.8"
+serde_json = "1"
 slug = "0.1.2"
 
 [features]

--- a/build.rs
+++ b/build.rs
@@ -3,7 +3,6 @@
 extern crate serde_json;
 extern crate slug;
 
-use std::collections::BTreeMap;
 use std::env;
 use std::path::Path;
 use std::fs::{self, File};
@@ -49,7 +48,7 @@ pub fn load_test_suites() -> Vec<(String, Value)> {
         let mut file_data = String::new();
         f.read_to_string(&mut file_data).expect("Could to read JSON to string");
         let mut suite_json: Value = serde_json::from_str(&file_data).expect("invalid JSON");
-        let mut suites = suite_json.as_array_mut().expect("Test suite is not a JSON array");
+        let suites = suite_json.as_array_mut().expect("Test suite is not a JSON array");
         while let Some(suite) = suites.pop() {
             result.push((file_path.clone(), suite));
         }
@@ -59,7 +58,7 @@ pub fn load_test_suites() -> Vec<(String, Value)> {
 
 /// Gets the expression from a test case with helpful error messages.
 #[inline]
-fn get_expr(case: &BTreeMap<String, Value>) -> &str {
+fn get_expr(case: &serde_json::Map<String, Value>) -> &str {
     case.get("expression")
         .expect("No expression in case")
         .as_str()
@@ -82,7 +81,7 @@ fn slugify(s: &str) -> String {
 fn generate_fn_name(filename: &str,
                     suite_num: usize,
                     case_num: usize,
-                    case: &BTreeMap<String, Value>) -> String {
+                    case: &serde_json::Map<String, Value>) -> String {
     let expr = get_expr(case);
     // Use the comment as the fn description if it is present.
     let description = match case.get("comment") {
@@ -99,7 +98,7 @@ fn generate_fn_name(filename: &str,
 fn generate_bench(filename: &str,
                   suite_num: usize,
                   case_num: usize,
-                  case: &BTreeMap<String, Value>,
+                  case: &serde_json::Map<String, Value>,
                   given_string: &str,
                   f: &mut File) {
     let expr = get_expr(case);
@@ -153,7 +152,7 @@ fn {}_full(b: &mut Bencher) {{
 fn generate_test(filename: &str,
                  suite_num: usize,
                  case_num: usize,
-                 case: &BTreeMap<String, Value>,
+                 case: &serde_json::Map<String, Value>,
                  given_string: &str,
                  f: &mut File) {
     let fn_suffix = generate_fn_name(filename, suite_num, case_num, case);

--- a/jmespath-cli/Cargo.toml
+++ b/jmespath-cli/Cargo.toml
@@ -8,8 +8,8 @@ license = "MIT"
 name = "jp"
 
 [dependencies]
-serde = "^0.8"
-serde_json = "^0.8"
+serde = "1"
+serde_json = "1"
 clap = "^2.4"
 
 [dependencies.jmespath]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -307,7 +307,6 @@ mod tests {
     use ::Rcvar;
     use ::variable::Variable;
     use super::*;
-    use super::Token::*;
 
     fn tokenize_queue(expr: &str) -> Vec<TokenTuple> {
         let mut result = tokenize(expr).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,7 +104,7 @@ extern crate serde_json;
 pub use errors::{JmespathError, ErrorReason, RuntimeError};
 pub use parser::{parse, ParseResult};
 pub use runtime::Runtime;
-pub use variable::Variable;
+pub use variable::{Variable, to_variable};
 
 pub mod ast;
 pub mod functions;
@@ -176,16 +176,14 @@ pub trait ToJmespath {
 impl<'a, T: ser::Serialize> ToJmespath for T {
     #[cfg(not(feature = "specialized"))]
     fn to_jmespath(self) -> Rcvar {
-        let mut ser = Serializer::new();
-        self.serialize(&mut ser).ok().unwrap();
-        Rcvar::new(ser.unwrap())
+        let variable = self.serialize(Serializer).unwrap();
+        Rcvar::new(variable)
     }
 
     #[cfg(feature = "specialized")]
     default fn to_jmespath(self) -> Rcvar {
-        let mut ser = Serializer::new();
-        self.serialize(&mut ser).ok().unwrap();
-        Rcvar::new(ser.unwrap())
+        let variable = self.serialize(Serializer).unwrap();
+        Rcvar::new(variable)
     }
 }
 


### PR DESCRIPTION
cc #23 

This PR approaches the serde upgrade by changing as little code as possible. It appears to be slightly faster than master :)

Please note that this is a breaking change. Would you be able to publish 0.2 after this change?

Benchmarks:

master

```
running 30 tests
test benchmarks_179_0_field_50_parse_lex                ... bench:      13,790 ns/iter (+/- 240)
test benchmarks_179_1_pipe_50_parse_lex                 ... bench:      14,053 ns/iter (+/- 372)
test benchmarks_179_2_index_50_parse_lex                ... bench:      12,791 ns/iter (+/- 231)
test benchmarks_179_3_long_raw_string_literal_parse_lex ... bench:       1,228 ns/iter (+/- 18)
test benchmarks_179_4_deep_projection_104_parse_lex     ... bench:      34,080 ns/iter (+/- 1,768)
test benchmarks_179_5_filter_projection_parse_lex       ... bench:       1,419 ns/iter (+/- 30)
test benchmarks_180_0_deep_ands_full                    ... bench:      12,408 ns/iter (+/- 244)
test benchmarks_180_0_deep_ands_interpret               ... bench:       5,682 ns/iter (+/- 81)
test benchmarks_180_0_deep_ands_parse_lex               ... bench:       6,205 ns/iter (+/- 93)
test benchmarks_180_1_deep_ors_full                     ... bench:      11,664 ns/iter (+/- 304)
test benchmarks_180_1_deep_ors_interpret                ... bench:       4,926 ns/iter (+/- 77)
test benchmarks_180_1_deep_ors_parse_lex                ... bench:       6,211 ns/iter (+/- 98)
test benchmarks_180_2_lots_of_summing_full              ... bench:      10,782 ns/iter (+/- 295)
test benchmarks_180_2_lots_of_summing_interpret         ... bench:       5,808 ns/iter (+/- 84)
test benchmarks_180_2_lots_of_summing_parse_lex         ... bench:       4,227 ns/iter (+/- 47)
test benchmarks_180_3_lots_of_multi_list_full           ... bench:      10,503 ns/iter (+/- 443)
test benchmarks_180_3_lots_of_multi_list_interpret      ... bench:       5,688 ns/iter (+/- 147)
test benchmarks_180_3_lots_of_multi_list_parse_lex      ... bench:       4,028 ns/iter (+/- 73)
test benchmarks_181_0_simple_field_full                 ... bench:       3,652 ns/iter (+/- 122)
test benchmarks_181_0_simple_field_interpret            ... bench:       3,353 ns/iter (+/- 55)
test benchmarks_181_0_simple_field_parse_lex            ... bench:         185 ns/iter (+/- 5)
test benchmarks_181_1_simple_subexpression_full         ... bench:       3,867 ns/iter (+/- 109)
test benchmarks_181_1_simple_subexpression_interpret    ... bench:       3,360 ns/iter (+/- 61)
test benchmarks_181_1_simple_subexpression_parse_lex    ... bench:         404 ns/iter (+/- 9)
test benchmarks_181_2_deep_field_selection_full         ... bench:       8,341 ns/iter (+/- 331)
test benchmarks_181_2_deep_field_selection_interpret    ... bench:       3,720 ns/iter (+/- 80)
test benchmarks_181_2_deep_field_selection_parse_lex    ... bench:       4,244 ns/iter (+/- 113)
test benchmarks_181_3_simple_or_full                    ... bench:       4,131 ns/iter (+/- 56)
test benchmarks_181_3_simple_or_interpret               ... bench:       3,404 ns/iter (+/- 45)
test benchmarks_181_3_simple_or_parse_lex               ... bench:         570 ns/iter (+/- 30)

test result: ok. 0 passed; 0 failed; 0 ignored; 30 measured; 0 filtered out
```

PR #23 branch

```
running 30 tests
test benchmarks_179_0_field_50_parse_lex                ... bench:      13,345 ns/iter (+/- 367)
test benchmarks_179_1_pipe_50_parse_lex                 ... bench:      13,750 ns/iter (+/- 237)
test benchmarks_179_2_index_50_parse_lex                ... bench:      12,774 ns/iter (+/- 184)
test benchmarks_179_3_long_raw_string_literal_parse_lex ... bench:       1,234 ns/iter (+/- 16)
test benchmarks_179_4_deep_projection_104_parse_lex     ... bench:      34,287 ns/iter (+/- 591)
test benchmarks_179_5_filter_projection_parse_lex       ... bench:       1,391 ns/iter (+/- 31)
test benchmarks_180_0_deep_ands_full                    ... bench:      17,630 ns/iter (+/- 331)
test benchmarks_180_0_deep_ands_interpret               ... bench:      11,252 ns/iter (+/- 768)
test benchmarks_180_0_deep_ands_parse_lex               ... bench:       6,025 ns/iter (+/- 179)
test benchmarks_180_1_deep_ors_full                     ... bench:      16,904 ns/iter (+/- 374)
test benchmarks_180_1_deep_ors_interpret                ... bench:      10,539 ns/iter (+/- 201)
test benchmarks_180_1_deep_ors_parse_lex                ... bench:       6,050 ns/iter (+/- 143)
test benchmarks_180_2_lots_of_summing_full              ... bench:      16,239 ns/iter (+/- 343)
test benchmarks_180_2_lots_of_summing_interpret         ... bench:      11,425 ns/iter (+/- 139)
test benchmarks_180_2_lots_of_summing_parse_lex         ... bench:       4,317 ns/iter (+/- 251)
test benchmarks_180_3_lots_of_multi_list_full           ... bench:      15,887 ns/iter (+/- 158)
test benchmarks_180_3_lots_of_multi_list_interpret      ... bench:      11,275 ns/iter (+/- 150)
test benchmarks_180_3_lots_of_multi_list_parse_lex      ... bench:       4,128 ns/iter (+/- 59)
test benchmarks_181_0_simple_field_full                 ... bench:      30,265 ns/iter (+/- 352)
test benchmarks_181_0_simple_field_interpret            ... bench:      29,648 ns/iter (+/- 484)
test benchmarks_181_0_simple_field_parse_lex            ... bench:         182 ns/iter (+/- 5)
test benchmarks_181_1_simple_subexpression_full         ... bench:      30,671 ns/iter (+/- 636)
test benchmarks_181_1_simple_subexpression_interpret    ... bench:      29,634 ns/iter (+/- 387)
test benchmarks_181_1_simple_subexpression_parse_lex    ... bench:         390 ns/iter (+/- 5)
test benchmarks_181_2_deep_field_selection_full         ... bench:      35,006 ns/iter (+/- 551)
test benchmarks_181_2_deep_field_selection_interpret    ... bench:      30,040 ns/iter (+/- 328)
test benchmarks_181_2_deep_field_selection_parse_lex    ... bench:       4,116 ns/iter (+/- 121)
test benchmarks_181_3_simple_or_full                    ... bench:      31,020 ns/iter (+/- 1,202)
test benchmarks_181_3_simple_or_interpret               ... bench:      29,770 ns/iter (+/- 1,009)
test benchmarks_181_3_simple_or_parse_lex               ... bench:         559 ns/iter (+/- 16)

test result: ok. 0 passed; 0 failed; 0 ignored; 30 measured; 0 filtered out
```

This PR

```
running 30 tests
test benchmarks_179_0_field_50_parse_lex                ... bench:      13,095 ns/iter (+/- 175)
test benchmarks_179_1_pipe_50_parse_lex                 ... bench:      13,446 ns/iter (+/- 243)
test benchmarks_179_2_index_50_parse_lex                ... bench:      12,241 ns/iter (+/- 145)
test benchmarks_179_3_long_raw_string_literal_parse_lex ... bench:       1,225 ns/iter (+/- 24)
test benchmarks_179_4_deep_projection_104_parse_lex     ... bench:      33,922 ns/iter (+/- 777)
test benchmarks_179_5_filter_projection_parse_lex       ... bench:       1,437 ns/iter (+/- 33)
test benchmarks_180_0_deep_ands_full                    ... bench:      10,901 ns/iter (+/- 169)
test benchmarks_180_0_deep_ands_interpret               ... bench:       4,553 ns/iter (+/- 37)
test benchmarks_180_0_deep_ands_parse_lex               ... bench:       5,646 ns/iter (+/- 238)
test benchmarks_180_1_deep_ors_full                     ... bench:       9,645 ns/iter (+/- 60)
test benchmarks_180_1_deep_ors_interpret                ... bench:       3,894 ns/iter (+/- 19)
test benchmarks_180_1_deep_ors_parse_lex                ... bench:       5,643 ns/iter (+/- 73)
test benchmarks_180_2_lots_of_summing_full              ... bench:       9,045 ns/iter (+/- 68)
test benchmarks_180_2_lots_of_summing_interpret         ... bench:       4,718 ns/iter (+/- 61)
test benchmarks_180_2_lots_of_summing_parse_lex         ... bench:       4,126 ns/iter (+/- 31)
test benchmarks_180_3_lots_of_multi_list_full           ... bench:       8,689 ns/iter (+/- 54)
test benchmarks_180_3_lots_of_multi_list_interpret      ... bench:       4,585 ns/iter (+/- 109)
test benchmarks_180_3_lots_of_multi_list_parse_lex      ... bench:       3,889 ns/iter (+/- 22)
test benchmarks_181_0_simple_field_full                 ... bench:       3,008 ns/iter (+/- 18)
test benchmarks_181_0_simple_field_interpret            ... bench:       2,810 ns/iter (+/- 20)
test benchmarks_181_0_simple_field_parse_lex            ... bench:         172 ns/iter (+/- 1)
test benchmarks_181_1_simple_subexpression_full         ... bench:       3,215 ns/iter (+/- 24)
test benchmarks_181_1_simple_subexpression_interpret    ... bench:       2,824 ns/iter (+/- 26)
test benchmarks_181_1_simple_subexpression_parse_lex    ... bench:         363 ns/iter (+/- 7)
test benchmarks_181_2_deep_field_selection_full         ... bench:       7,109 ns/iter (+/- 111)
test benchmarks_181_2_deep_field_selection_interpret    ... bench:       3,210 ns/iter (+/- 44)
test benchmarks_181_2_deep_field_selection_parse_lex    ... bench:       3,793 ns/iter (+/- 31)
test benchmarks_181_3_simple_or_full                    ... bench:       3,438 ns/iter (+/- 45)
test benchmarks_181_3_simple_or_interpret               ... bench:       2,871 ns/iter (+/- 12)
test benchmarks_181_3_simple_or_parse_lex               ... bench:         526 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 30 measured; 0 filtered out
``` 
