### PR TITLE
Problem: Expression/Runtime coupling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ use ast::Ast;
 use variable::Serializer;
 use interpreter::{interpret, SearchResult};
 
-mod interpreter;
+pub mod interpreter;
 mod parser;
 mod lexer;
 mod runtime;


### PR DESCRIPTION
Right now, `Expression` and `Runtime` are inherently coupled. However,
it seems that the main motivation for this is the API convenience.
However, this creates certain level of confusion.

Like, why does `Runtime` has a `compile` function? (Isn't runtime
supposed to be about, well, run time as opposed to compile time?). Or,
equally interesting -- why does `Expression` have to carry a reference
to `Runtime`? Can't it be interpreted on different `Runtime`s?

Solution: make `interpret` module public

This doesn't fully resolve the issue described, but it does allow to
decouple these structures as an opt-in for those users that have a
reason to do so (for example, to avoid the necessity of carrying a
reference to Runtime around -- something that would also not be very
compatible with trait associated types).

---

I am also contemplating a much heavier to change that would do a proper rehaul of concepts and structures to avoid unnecessary coupling, but for now this is the smallest possible change that I think will alleviate the coupling issues (in my particular case, I am only able to use Expression<'static> as an associated trait type while I don't really want to impose that lifetime restriction on runtimes) 