### PR TITLE
Fix serde Error

### DIFF
--- a/src/variable.rs
+++ b/src/variable.rs
@@ -6,7 +6,7 @@ extern crate serde_json;
 use std::vec;
 use serde::{de, ser};
 use serde::de::IntoDeserializer;
-use serde_json::error::{Error, ErrorCode};
+use serde_json::error::Error;
 use serde_json::value::Value;
 use std::collections::BTreeMap;
 use std::cmp::{max, Ordering};
@@ -1202,7 +1202,7 @@ impl ser::SerializeMap for MapState {
     {
         match to_variable(key)? {
             Variable::String(s) => self.next_key = Some(s),
-            _ => return Err(Error::syntax(ErrorCode::KeyMustBeAString, 0, 0)),
+            _ => return Err(de::Error::custom("KeyMustBeAString")),
         };
         Ok(())
     }


### PR DESCRIPTION
ErrorCode and syntax seem to have become private, so I implemented just using a custom de::Error instead of serde_json::Error::syntax. Not sure if this is what is needed. Let me know.